### PR TITLE
Allow integer options

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -1,18 +1,16 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },
-   "outputs": [],
    "source": [
     "# tulipy\n",
     "\n",
     "## Python bindings for [Tulip Indicators](https://tulipindicators.org/)\n",
     "\n",
-    "Tulipy requires [numpy](http://www.numpy.org/) as all inputs and outputs are numpy arrays (`dtype=np.float64`). "
+    "Tulipy requires [numpy](http://www.numpy.org/) as all inputs and outputs are numpy arrays (`dtype=np.float64`)."
    ]
   },
   {
@@ -183,7 +181,7 @@
     }
    ],
    "source": [
-    "ti.sma(DATA, period=5.0)"
+    "ti.sma(DATA, period=5)"
    ]
   },
   {
@@ -210,7 +208,7 @@
    ],
    "source": [
     "try:\n",
-    "    ti.sma(DATA, period=-5.0)\n",
+    "    ti.sma(DATA, period=-5)\n",
     "except ti.InvalidOptionError:\n",
     "    print \"Invalid Option!\""
    ]
@@ -264,7 +262,7 @@
     }
    ],
    "source": [
-    "ti.bbands(DATA, period=5.0, stddev=2.0)"
+    "ti.bbands(DATA, period=5, stddev=2)"
    ]
   },
   {
@@ -309,21 +307,12 @@
     "# 'high' trimmed to DATA[-5:] == array([ 85.53,  86.54,  86.89,  87.77,  87.29])\n",
     "ti.aroonosc(high=DATA, low=DATA2, period=2.0)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 2",
    "language": "python",
    "name": "python2"
   },
@@ -337,7 +326,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ print_info(ti.sqrt)
     Inputs: ['real']
     Options: []
     Outputs: ['sqrt']
-    
+
 
 Single outputs are returned directly. Indicators returning multiple outputs use
 a tuple in the order indicated by the `outputs` property.
@@ -82,11 +82,11 @@ print_info(ti.sma)
     Inputs: ['real']
     Options: ['period']
     Outputs: ['sma']
-    
+
 
 
 ```python
-ti.sma(DATA, period=5.0)
+ti.sma(DATA, period=5)
 ```
 
 
@@ -102,13 +102,13 @@ Invalid options will throw an `InvalidOptionError`:
 
 ```python
 try:
-    ti.sma(DATA, period=-5.0)
+    ti.sma(DATA, period=-5)
 except ti.InvalidOptionError:
     print "Invalid Option!"
 ```
 
     Invalid Option!
-    
+
 
 
 ```python
@@ -120,11 +120,11 @@ print_info(ti.bbands)
     Inputs: ['real']
     Options: ['period', 'stddev']
     Outputs: ['bbands_lower', 'bbands_middle', 'bbands_upper']
-    
+
 
 
 ```python
-ti.bbands(DATA, period=5.0, stddev=2.0)
+ti.bbands(DATA, period=5, stddev=2)
 ```
 
 
@@ -159,10 +159,4 @@ ti.aroonosc(high=DATA, low=DATA2, period=2.0)
 
     array([  50.,  100.,   50.])
 
-
-
-
-```python
-
-```
 

--- a/gen/tulipy_gen.pyx
+++ b/gen/tulipy_gen.pyx
@@ -94,7 +94,7 @@ cdef class _Indicator:
             min_input_len = __builtin__.min(min_input_len, inputs[i].shape[0])
 
         option_list = options if options else [0.0]
-        cdef np.ndarray[np.float64_t, ndim=1, mode='c'] c_options = np.array(option_list)
+        cdef np.ndarray[np.float64_t, ndim=1, mode='c'] c_options = np.array(option_list, dtype=np.float64)
 
         delta = self.info.start(&c_options[0])
         if min_input_len - delta <= 0:

--- a/tulipy/lib/__init__.pyx
+++ b/tulipy/lib/__init__.pyx
@@ -65,7 +65,7 @@ cdef class _Indicator:
             min_input_len = __builtin__.min(min_input_len, inputs[i].shape[0])
 
         option_list = options if options else [0.0]
-        cdef np.ndarray[np.float64_t, ndim=1, mode='c'] c_options = np.array(option_list)
+        cdef np.ndarray[np.float64_t, ndim=1, mode='c'] c_options = np.array(option_list, dtype=np.float64)
 
         delta = self.info.start(&c_options[0])
         if min_input_len - delta <= 0:


### PR DESCRIPTION
Cast to `np.float64` when creating `c_options`.

Fixes #8.