### PR TITLE
Fix PyPI package build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft libindicators

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,14 @@ ext_modules = [
 setup(
     name='tulipy',
     description='Python bindings for https://github.com/TulipCharts/tulipindicators',
-    version=0.1,
+    version='0.1.1',
     url='https://github.com/cirla/tulipy',
     author='https://github.com/cirla/tulipy/blob/master/AUTHORS',
     license='LGPL-3.0',
     cmdclass={'build_ext': build_ext},
     ext_modules=ext_modules,
     packages=find_packages(exclude=["tests"]),
-    setup_requires=['Cython', 'numpy'],
+    install_requires=['Cython', 'numpy'],
     requires=['numpy'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Fixes #12 

Now `sdist` tar.gz includes indicators.h and install should grab the proper dependencies.