### PR TITLE
cleanup readme/test, uprev version

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -312,7 +312,7 @@
    ],
    "source": [
     "# 'high' trimmed to DATA[-5:] == array([ 85.53,  86.54,  86.89,  87.77,  87.29])\n",
-    "ti.aroonosc(high=DATA, low=DATA2, period=2.0)"
+    "ti.aroonosc(high=DATA, low=DATA2, period=2)"
    ]
   }
  ],

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ DATA2 = np.array([83.15, 82.84, 83.99, 84.55, 84.36])
 
 ```python
 # 'high' trimmed to DATA[-5:] == array([ 85.53,  86.54,  86.89,  87.77,  87.29])
-ti.aroonosc(high=DATA, low=DATA2, period=2.0)
+ti.aroonosc(high=DATA, low=DATA2, period=2)
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ ext_modules = [
 setup(
     name='tulipy',
     description='Python bindings for https://github.com/TulipCharts/tulipindicators',
-    version='0.1.2',
+    version='0.2',
     url='https://github.com/cirla/tulipy',
     author='https://github.com/cirla/tulipy/blob/master/AUTHORS',
     license='LGPL-3.0',

--- a/tests/test.py
+++ b/tests/test.py
@@ -14,7 +14,7 @@ class TestIndicators(unittest.TestCase):
                              83.778, 84.254, 84.994, 85.574, 86.218,
                              86.804]),
 
-        actual = ti.sma(CLOSE, period=5.0)
+        actual = ti.sma(CLOSE, period=5)
 
         self.assertTrue(np.allclose(actual, expected))
 


### PR DESCRIPTION
Use int params in examples/tests where floats don't make sense (e.g. `period`).
Increase package version to release these changes alongside #14