### PR TITLE
get Github to consider this a Python repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-vendored
+*.py linguist-vendored=false


### PR DESCRIPTION
This will make Github consider the repo as Python code, which I think will make it easier to find for Python coders. Right now, it is listed as C code. If you merge this, it takes a while for Github to update the code stats.